### PR TITLE
bugfix: 修复线程循环时，anchor_name读取逻辑错误

### DIFF
--- a/main.py
+++ b/main.py
@@ -979,11 +979,14 @@ def start_record(url_data: tuple, count_variable: int = -1):
                         return
 
                     if anchor_name:
-                        anchor_split: list = anchor_name.split('主播:')
-                        if len(anchor_split) > 1 and anchor_split[1].strip():
-                            anchor_name = anchor_split[1].strip()
-                        else:
-                            anchor_name = port_info.get("anchor_name", '')
+                        # 第一次从config中读取，带有'主播:'，去除'主播:'
+                        # 之后的线程循环，已经是处理后的结果，不需要去处理
+                        if '主播:' in anchor_name:
+                            anchor_split: list = anchor_name.split('主播:')
+                            if len(anchor_split) > 1 and anchor_split[1].strip():
+                                anchor_name = anchor_split[1].strip()
+                            else:
+                                anchor_name = port_info.get("anchor_name", '')
                     else:
                         anchor_name = port_info.get("anchor_name", '')
 


### PR DESCRIPTION
现象：
发现用户改名之后，录制的直播名称用的是新的，而不是`URL_config.ini`里存的。

原因：
线程第一次进入，去掉`anchor_name`里的'主播:'，逻辑正确；
线程从第二次循环开始，`anchor_name`已经不带有'主播:'，再进入下面的`if`，进入986行，就会导致`port_info`中的`anchor_name`覆盖掉config中已有的。
https://github.com/ihmily/DouyinLiveRecorder/blob/5e0a7360446beba085a31ce1b163a13307c6f86e/main.py#L981-L988

> 微小的贡献，希望可以被合并，谢谢🥳🥳🥳