### PR TITLE
fix: graceful exit when disk usage threshold is reached

### DIFF
--- a/main.py
+++ b/main.py
@@ -1932,10 +1932,10 @@ while True:
     check_path = video_save_path or default_path
     if utils.check_disk_capacity(check_path, show=first_run) < disk_space_limit:
         exit_recording = True
-        if not recording:
-            logger.warning(f"Disk space remaining is below {disk_space_limit} GB. "
-                           f"Exiting program due to the disk space limit being reached.")
-            sys.exit(-1)
+    if exit_recording and not recording:
+        logger.warning(f"Disk space remaining is below {disk_space_limit} GB. "
+                        f"Exiting program due to the disk space limit being reached.")
+        sys.exit(-1)
 
 
     def contains_url(string: str) -> bool:


### PR DESCRIPTION
### 📜 标题（Title）

**请提供这个Pull Request中提议的更改的简洁描述：**  
<!-- Please provide a succinct description of the changes proposed in this pull request:. -->

- 修复磁盘不足时graceful exit的条件

### 🔍 描述（Description）

**请描述这个PR做了什么/为什么这些更改是必要的：**
<!-- Please describe what this PR does / why these changes are necessary: -->

- 如果触发磁盘不足后，在下次检测之前如果磁盘空间恢复，那程序不会退出，一直卡在退出中的流程；后续所有直播都不会被录制。
- 修改退出条件为进入退出流程后，只要完成所有直播的中断后就退出程序。 

### 📝 类型（Type of Change）

**这个PR引入了哪种类型的更改？（请勾选所有适用的选项）**
<!-- What type of change does this PR introduce? (Check all that apply)  -->

- [x] 修复Bug  <!-- Bugfix -->

---

**感谢您的贡献！**
<!-- Thank you for your contribution! -->