### PR TITLE
Fix ghost monitoring after removing URL from URL_config.ini

### DIFF
--- a/main.py
+++ b/main.py
@@ -1946,6 +1946,7 @@ while True:
 
     try:
         url_comments, line_list, url_line_list = [[] for _ in range(3)]
+        seen_urls = set()
         with (open(url_config_file, "r", encoding=text_encoding, errors='ignore') as file):
             for origin_line in file:
                 if origin_line in line_list:
@@ -2098,6 +2099,7 @@ while True:
                             new_url = url.split('?')[0] + f'?host_id={host_id.group(1)}'
                             url = update_file(url_config_file, old_str=url, new_str=new_url)
 
+                    seen_urls.add(url)
                     url_comments = [i for i in url_comments if url not in i]
                     if is_comment_line:
                         url_comments.append(url)
@@ -2120,6 +2122,11 @@ while True:
                     start_with = None
                     new_word = replace_words[1]
                 update_file(url_config_file, old_str=replace_words[0], new_str=new_word, start_str=start_with)
+
+        running_snapshot = list(running_list)
+        for running_url in running_snapshot:
+            if running_url not in seen_urls and running_url not in url_comments:
+                url_comments.append(running_url)
 
         text_no_repeat_url = list(set(url_tuples_list))
 


### PR DESCRIPTION
### 📜 标题（Title）

**请提供这个Pull Request中提议的更改的简洁描述：**  

- Fix ghost monitoring after removing URL from URL_config.ini

### 🔍 描述（Description）

**请描述这个PR做了什么/为什么这些更改是必要的：**

- Fixes a stale monitoring state when a live URL is removed directly from `config/URL_config.ini`.
- Previously, the stop path only handled commented URLs, so a URL deleted from the config could remain in `running_list` and keep showing as monitored.
- This change compares the current running URL list with the URLs still present in the config during reload, and appends missing running URLs to `url_comments`.
- This reuses the existing worker stop-and-cleanup flow instead of introducing a separate cleanup path.

### 📝 类型（Type of Change）

**这个PR引入了哪种类型的更改？（请勾选所有适用的选项）**

- [x] 修复Bug
- [ ] 新功能
- [ ] 代码风格更新（格式化，局部变量）
- [ ] 重构（改进代码结构）
- [ ] 构建相关更改（依赖项，构建脚本等）
- [ ] 其他：_请描述_

### 🏗️ 测试（Testing）

**请描述您已经进行的测试：**

- Manually tested by adding a live URL, waiting until it entered monitoring state, then deleting the URL line directly from `config/URL_config.ini`.
- Verified that the deleted URL was routed through the existing stop signal path and the monitoring entry was cleared cleanly.
- Verified syntax with `python3 -m py_compile main.py`.

**如果适用，请提供测试更改的说明：**

- Start the program with a valid live URL in `config/URL_config.ini`.
- Wait until the URL enters monitoring state.
- Delete the URL line directly from `config/URL_config.ini`.
- Wait for the next config reload cycle and confirm the monitoring entry disappears.

### 📋 检查清单（Checklist）

在您创建这个PR之前，请确保以下所有框都被勾选，方法是在每个框中放置一个`x`：

- [x] 我已经阅读了**贡献指南**文档
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了覆盖我更改的测试
- [ ] 我已经相应地更新了文档（如果适用）
- [x] 我遵循了这个项目的代码风格
---
**感谢您的贡献！**