### PR TITLE
Add semantic runtime events and make per-room retry waits interruptible

### DIFF
--- a/RUNTIME_EVENTS.md
+++ b/RUNTIME_EVENTS.md
@@ -1,0 +1,206 @@
+# Runtime Events / 运行时事件
+
+> **Language and AI assistance note / 语言及 AI 协助说明**  
+> The contributor does not speak, read, or write Chinese. Please excuse any inaccuracies in the Chinese wording. The Chinese translation and wording of this document were prepared with assistance from ChatGPT. The feature design, Python implementation, debugging, and testing were carried out collaboratively by the contributor and ChatGPT.  
+> 提交者不会说、读或写中文。如中文表述有不准确之处，敬请谅解。本文档的中文翻译及文字整理由 ChatGPT 协助完成；相关功能的设计、Python 实现、调试和测试由提交者与 ChatGPT 共同完成。
+
+## Purpose / 用途
+
+DouyinLiveRecorder can write semantic runtime state as JSON Lines (JSONL) to `logs/runtime_events.jsonl`. This allows external GUIs, web frontends, monitoring applications, and automation tools to observe accurate recorder state in real time without needing to parse human-oriented console output.
+
+DouyinLiveRecorder 可以将语义化的运行状态以 JSON Lines（JSONL）格式写入 `logs/runtime_events.jsonl`。这样，外部 GUI、Web 前端、监控程序和自动化工具可以实时获取准确的录制程序状态，而无需解析主要面向人工阅读的控制台输出。
+
+**The bridge observes existing recorder behavior; it does not alter the recording workflow.**
+
+**该桥接仅观察现有录制程序的行为，不改变录制工作流程。**
+
+The runtime-event hooks are intentionally passive and read-only. They do not provide a command or control channel. Apart from a small related bugfix that makes a disabled room leave its per-room retry wait promptly, the existing recording logic is not changed by this contribution.
+
+运行时事件钩子被有意设计为被动且只读，不提供命令或控制通道。除了一处相关的小型修复——使被禁用的直播间能够及时退出其自身的重试等待——本次贡献不改变现有录制逻辑。
+
+## Event file / 事件文件
+
+The event file is UTF-8 encoded and contains one independent JSON object per line.
+
+事件文件使用 UTF-8 编码，每行包含一个独立的 JSON 对象。
+
+The path is relative to the application directory:
+
+事件文件路径相对于应用程序目录：
+
+```text
+logs/runtime_events.jsonl
+```
+
+When running from source, the application directory is the directory containing `runtime_events.py`. In a frozen/PyInstaller build, it is the directory containing the executable.
+
+以源码方式运行时，应用程序目录是包含 `runtime_events.py` 的目录。在冻结/PyInstaller 打包版本中，则是包含可执行文件的目录。
+
+Every event contains:
+
+每个事件都包含：
+
+- `timestamp` — UTC timestamp in ISO 8601 format / UTC ISO 8601 格式时间戳
+- `event` — semantic event name / 语义事件名称
+
+Event writing is best-effort. Failure to create the log directory or write an event is ignored and does not alter recorder operation.
+
+事件写入采用尽力而为（best-effort）方式。如果日志目录无法创建或事件无法写入，该错误会被忽略，不会影响录制程序本身的运行。
+
+## Events / 事件
+
+### `runtime_started`
+
+Emitted after runtime initialization has completed sufficiently for the main recorder loop to start.
+
+当运行环境初始化完成到足以进入主录制循环时发出。
+
+Additional fields / 附加字段:
+
+- `version`
+
+---
+
+### `room_monitoring_started`
+
+Emitted once when a worker begins monitoring a configured room.
+
+当工作线程开始监测一个已配置的直播间时发出一次。
+
+Additional fields / 附加字段:
+
+- `url` — configured room URL / 已配置的直播间 URL
+- `quality` — configured recording quality / 已配置的录制质量
+
+---
+
+### `room_monitoring_stopped`
+
+Emitted when monitoring of a configured room is stopped and the room is removed from the active monitoring list.
+
+当已配置直播间的监测停止，并从活动监测列表中移除时发出。
+
+Additional fields / 附加字段:
+
+- `url` — configured room URL / 已配置的直播间 URL
+
+---
+
+### `room_live`
+
+Emitted when the resolver reports that a monitored room is live.
+
+当解析器报告被监测的直播间正在直播时发出。
+
+Additional fields / 附加字段:
+
+- `url`
+- `platform`
+- `anchor`
+- `quality`
+
+---
+
+### `room_waiting`
+
+Emitted once before a worker enters a retry/wait period.
+
+在工作线程进入重试/等待周期之前发出一次。
+
+Additional fields / 附加字段:
+
+- `url`
+- `platform`
+- `anchor`
+- `quality`
+- `retry_after` — actual wait duration in seconds / 实际等待秒数
+- `next_check` — calculated next-check time in UTC ISO 8601 format / 计算出的下一次检查时间（UTC ISO 8601）
+
+This allows an external UI to maintain its own countdown without parsing console output.
+
+这样，外部 UI 可以自行显示倒计时，而无需解析控制台输出。
+
+---
+
+### `recording_started`
+
+Emitted after a recording backend has successfully started.
+
+当录制后端成功启动后发出。
+
+Additional fields / 附加字段:
+
+- `url` — configured room URL / 已配置的直播间 URL
+- `backend` — currently `ffmpeg` or `direct_flv` / 当前为 `ffmpeg` 或 `direct_flv`
+- `output_path`
+- `format`
+
+For the direct FLV backend, this event is emitted only after the HTTP stream request has succeeded.
+
+对于 direct FLV 后端，仅在 HTTP 直播流请求成功后才发出此事件。
+
+---
+
+### `recording_stopped`
+
+Emitted after a previously started recording session stops.
+
+当之前已经启动的录制会话停止后发出。
+
+Additional fields / 附加字段:
+
+- `url`
+- `backend`
+- `output_path`
+- `format`
+- `reason`
+- `return_code` — present for FFmpeg backend completion/error where applicable / 在适用的 FFmpeg 后端完成或错误情况下提供
+
+Current `reason` values / 当前 `reason` 值:
+
+- `disabled` — the configured room was disabled/commented / 已配置直播间被禁用或注释
+- `disk_space_limit` — recording was stopped because the configured free-space limit was reached / 因达到配置的剩余磁盘空间限制而停止录制
+- `completed` — backend exited normally / 后端正常结束
+- `backend_error` — backend stopped with an error / 后端因错误而停止
+
+## Privacy and security / 隐私与安全
+
+The runtime event bridge intentionally does **not** emit sensitive runtime information such as:
+
+运行时事件桥接有意**不输出**以下敏感运行信息：
+
+- cookies
+- passwords / 密码
+- authorization data / 授权信息
+- proxy credentials / 代理凭据
+- signed or direct stream URLs / 签名或直连直播流地址
+- raw resolver responses / 原始解析器响应
+- FFmpeg command lines / FFmpeg 命令行
+
+The `url` field refers to the configured public room URL, not the resolved/signed media stream URL.
+
+`url` 字段指的是已配置的公开直播间 URL，而不是解析得到的签名媒体流 URL。
+
+## Testing status / 测试状态
+
+The runtime-event hooks on the FFmpeg recording path were exercised with live Douyin rooms. The tests covered monitoring start/stop, live detection, recording start/stop, disabling and re-enabling a room, backend failure, retry waiting, and interruption of that waiting state. Other FFmpeg-based platforms were not separately exercised as part of this contribution.
+
+FFmpeg 录制路径上的运行时事件钩子已使用实际的抖音直播间进行了测试。测试涵盖监测开始/停止、直播检测、录制开始/停止、禁用和重新启用直播间、后端失败、重试等待以及中断该等待状态。本次贡献未单独测试其他基于 FFmpeg 的平台。
+
+The existing direct FLV recording logic was not changed by this contribution; only passive runtime-event emissions were added around its existing control flow. Those new `direct_flv` event hooks were reviewed and syntax-checked. Live verification was also attempted using the Huajiao and Shopee example room URLs supplied by the project, but neither example produced an active live stream during testing. The `direct_flv` hooks therefore could not yet be exercised in a real live recording session. This limitation concerns live verification of the newly added event reporting only, not the existing direct FLV recording functionality.
+
+本次贡献没有修改现有的 direct FLV 录制逻辑；只是在其现有控制流程周围增加了被动式运行时事件输出。新增的 `direct_flv` 事件钩子已经过代码审查和语法检查。我们还尝试使用项目提供的花椒和 Shopee 示例直播间 URL 进行实际验证，但测试时两个示例都没有产生正在进行的直播。因此，`direct_flv` 事件钩子目前尚未能在真实直播录制会话中触发验证。此限制仅涉及新增事件报告功能的实际直播验证，并不表示现有 direct FLV 录制功能存在问题。
+
+The event path was also verified in a PyInstaller onedir build, including creation of `logs/runtime_events.jsonl` beside the frozen executable.
+
+事件路径还在 PyInstaller onedir 打包版本中进行了验证，包括在冻结可执行文件旁创建 `logs/runtime_events.jsonl`。
+
+## Notes / 说明
+
+The event bridge is intended as a generic integration mechanism. It can be used by graphical frontends, web interfaces, monitoring tools, automation, or other external programs.
+
+该事件桥接旨在作为通用集成机制，可供图形界面、Web 接口、监控工具、自动化程序或其他外部程序使用。
+
+No schema version is currently defined. Consumers should ignore unknown fields and unknown event names so that the event stream can be extended in the future.
+
+目前尚未定义事件架构版本。使用方应忽略未知字段和未知事件名称，以便将来可以扩展事件流。

--- a/main.py
+++ b/main.py
@@ -372,13 +372,19 @@ def run_script(command: str) -> None:
         logger.error(e)
         logger.error('Please add `#!/bin/bash` at the beginning of your bash script file.')
 
+def clear_monitor_info(record_url: str) -> bool:
+    global monitoring
+
+    if record_url not in running_list:
+        return False
+
+    running_list.remove(record_url)
+    monitoring -= 1
+    return True
 
 def clear_record_info(record_name: str, record_url: str) -> None:
-    global monitoring
     recording.discard(record_name)
-    if record_url in url_comments and record_url in running_list:
-        running_list.remove(record_url)
-        monitoring -= 1
+    if record_url in url_comments and clear_monitor_info(record_url):
         color_obj.print_colored(f"[{record_name}]已经从录制列表中移除\n", color_obj.YELLOW)
 
 
@@ -1631,6 +1637,11 @@ def start_record(url_data: tuple, count_variable: int = -1) -> None:
 
                 # 这里是正常循环
                 while x:
+                    if record_url in url_comments:
+                        clear_monitor_info(record_url)
+                        return
+                    if exit_recording:
+                        return
                     x = x - 1
                     if loop_time:
                         print(f'\r{anchor_name}循环等待{x}秒 ', end="")

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ from msg_push import (
 from ffmpeg_install import (
     check_ffmpeg, ffmpeg_path, current_env_path
 )
+from runtime_events import emit_runtime_event
 
 version = "v4.0.7"
 platforms = ("\n国内站点：抖音|快手|虎牙|斗鱼|YY|B站|小红书|bigo|blued|网易CC|千度热播|猫耳FM|Look|TwitCasting|百度|微博|"
@@ -380,6 +381,10 @@ def clear_monitor_info(record_url: str) -> bool:
 
     running_list.remove(record_url)
     monitoring -= 1
+    emit_runtime_event(
+        "room_monitoring_stopped",
+        url=record_url
+    )
     return True
 
 def clear_record_info(record_name: str, record_url: str) -> None:
@@ -389,6 +394,7 @@ def clear_record_info(record_name: str, record_url: str) -> None:
 
 
 def direct_download_stream(source_url: str, save_path: str, record_name: str, live_url: str, platform: str) -> bool:
+    recording_started_emitted = False
     try:
         with open(save_path, 'wb') as f:
             client = httpx.Client(timeout=None)
@@ -404,22 +410,57 @@ def direct_download_stream(source_url: str, save_path: str, record_name: str, li
                     logger.error(f"请求直播流失败，状态码: {response.status_code}")
                     return False
 
+                emit_runtime_event(
+                    "recording_started",
+                    url=live_url,
+                    backend="direct_flv",
+                    output_path=save_path,
+                    format="FLV"
+                )
+                recording_started_emitted = True
+
                 downloaded = 0
                 chunk_size = 1024 * 16
 
                 for chunk in response.iter_bytes(chunk_size):
                     if live_url in url_comments or exit_recording:
+                        stop_reason = "disabled" if live_url in url_comments else "disk_space_limit"
                         color_obj.print_colored(f"[{record_name}]录制时已被注释或请求停止,下载中断", color_obj.YELLOW)
                         clear_record_info(record_name, live_url)
+                        emit_runtime_event(
+                            "recording_stopped",
+                            url=live_url,
+                            backend="direct_flv",
+                            output_path=save_path,
+                            format="FLV",
+                            reason=stop_reason
+                        )
                         return False
 
                     if chunk:
                         f.write(chunk)
                         downloaded += len(chunk)
                 print()
+                emit_runtime_event(
+                    "recording_stopped",
+                    url=live_url,
+                    backend="direct_flv",
+                    output_path=save_path,
+                    format="FLV",
+                    reason="completed"
+                )
                 return True
     except Exception as e:
         logger.error(f"FLV下载错误: {e} 发生错误的行数: {e.__traceback__.tb_lineno}")
+        if recording_started_emitted:
+            emit_runtime_event(
+                "recording_stopped",
+                url=live_url,
+                backend="direct_flv",
+                output_path=save_path,
+                format="FLV",
+                reason="backend_error"
+            )
         return False
 
 
@@ -428,6 +469,14 @@ def check_subprocess(record_name: str, record_url: str, ffmpeg_command: list, sa
     save_file_path = ffmpeg_command[-1]
     process = subprocess.Popen(
         ffmpeg_command, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, startupinfo=get_startup_info(os_type)
+    )
+
+    emit_runtime_event(
+        "recording_started",
+        url=record_url,
+        backend="ffmpeg",
+        output_path=save_file_path,
+        format=save_type
     )
 
     subs_file_path = save_file_path.rsplit('.', maxsplit=1)[0]
@@ -441,6 +490,7 @@ def check_subprocess(record_name: str, record_url: str, ffmpeg_command: list, sa
 
     while process.poll() is None:
         if record_url in url_comments or exit_recording:
+            stop_reason = "disabled" if record_url in url_comments else "disk_space_limit"
             color_obj.print_colored(f"[{record_name}]录制时已被注释,本条线程将会退出", color_obj.YELLOW)
             clear_record_info(record_name, record_url)
             # process.terminate()
@@ -451,10 +501,27 @@ def check_subprocess(record_name: str, record_url: str, ffmpeg_command: list, sa
             else:
                 process.send_signal(signal.SIGINT)
             process.wait()
+            emit_runtime_event(
+                "recording_stopped",
+                url=record_url,
+                backend="ffmpeg",
+                output_path=save_file_path,
+                format=save_type,
+                reason=stop_reason
+            )
             return True
         time.sleep(1)
 
     return_code = process.returncode
+    emit_runtime_event(
+        "recording_stopped",
+        url=record_url,
+        backend="ffmpeg",
+        output_path=save_file_path,
+        format=save_type,
+        reason="completed" if return_code == 0 else "backend_error",
+        return_code=return_code
+    )
     stop_time = time.strftime('%Y-%m-%d %H:%M:%S')
     if return_code == 0:
         if converts_to_mp4 and save_type == 'TS':
@@ -551,6 +618,8 @@ def select_source_url(link, stream_info):
 def start_record(url_data: tuple, count_variable: int = -1) -> None:
     global error_count
 
+    monitoring_started_emitted = False
+
     while True:
         try:
             record_finished = False
@@ -560,6 +629,14 @@ def start_record(url_data: tuple, count_variable: int = -1) -> None:
             count_time = time.time()
             retry = 0
             record_quality_zh, record_url, anchor_name = url_data
+
+            if not monitoring_started_emitted:
+                emit_runtime_event(
+                    "room_monitoring_started",
+                    url=record_url,
+                    quality=record_quality_zh
+                )
+                monitoring_started_emitted = True
             record_quality = get_quality_code(record_quality_zh)
             proxy_address = proxy_addr
             platform = '未知平台'
@@ -1101,6 +1178,14 @@ def start_record(url_data: tuple, count_variable: int = -1) -> None:
                             content = f"\r{record_name} 正在直播中..."
                             print(content)
 
+                            emit_runtime_event(
+                                "room_live",
+                                url=record_url,
+                                platform=platform,
+                                anchor=anchor_name,
+                                quality=record_quality_zh
+                            )
+
                             if live_status_push and not start_pushed:
                                 if begin_show_push:
                                     push_content = "直播间状态更新：[直播间名称] 正在直播中，时间：[时间]"
@@ -1635,6 +1720,20 @@ def start_record(url_data: tuple, count_variable: int = -1) -> None:
                 else:
                     x = num
 
+                if x > 0 and record_url not in url_comments and not exit_recording:
+                    emit_runtime_event(
+                        "room_waiting",
+                        url=record_url,
+                        platform=platform,
+                        anchor=anchor_name,
+                        quality=record_quality_zh,
+                        retry_after=x,
+                        next_check=(
+                            datetime.datetime.now(datetime.timezone.utc)
+                            + datetime.timedelta(seconds=x)
+                        ).isoformat()
+                    )
+
                 # 这里是正常循环
                 while x:
                     if record_url in url_comments:
@@ -1790,6 +1889,11 @@ except URLError:
                             color_obj.YELLOW)
 except Exception as err:
     print("An unexpected error occurred:", err)
+
+emit_runtime_event(
+    "runtime_started",
+    version=version
+)
 
 while True:
 

--- a/runtime_events.py
+++ b/runtime_events.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+
+_event_lock = threading.Lock()
+
+
+def _get_application_directory() -> str:
+    if getattr(sys, "frozen", False):
+        return os.path.dirname(sys.executable)
+
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def emit_runtime_event(event: str, **fields: Any) -> None:
+    try:
+        event_data = {
+            **fields,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+        }
+
+        log_directory = os.path.join(
+            _get_application_directory(),
+            "logs"
+        )
+        os.makedirs(log_directory, exist_ok=True)
+
+        event_file = os.path.join(
+            log_directory,
+            "runtime_events.jsonl"
+        )
+
+        line = json.dumps(
+            event_data,
+            ensure_ascii=False,
+            separators=(",", ":")
+        )
+
+        with _event_lock:
+            with open(event_file, "a", encoding="utf-8") as file:
+                file.write(line + "\n")
+
+    except Exception:
+        pass


### PR DESCRIPTION
> **Language and AI assistance note / 语言及 AI 协助说明**
>
> I do not speak, read, or write Chinese, so I apologize in advance for any inaccuracies in the Chinese wording. The Chinese translation and the organization of this Pull Request description were prepared with assistance from ChatGPT.
>
> The technical work in this contribution was also a joint effort between me and ChatGPT. I am not a Python programmer. I identified the required behavior, reproduced and investigated the retry issue, defined the runtime information needed by an external UI, reviewed the changes, and performed the source and frozen-build tests. ChatGPT assisted with the Python implementation, debugging, code review, wording, and translation.
>
> 我不会说、读或写中文，因此如果中文表述中有任何不准确之处，敬请谅解。本 Pull Request 的中文翻译以及说明文字的整理是在 ChatGPT 的协助下完成的。
>
> 本次贡献中的技术工作也是我与 ChatGPT 共同完成的。我并不是 Python 程序员；我确定了所需的行为，复现并调查了重试等待问题，定义了外部 UI 所需要的运行时信息，审查了修改，并进行了源码模式和打包版本测试。ChatGPT 协助完成了 Python 实现、调试、代码审查、文字整理和翻译。

### 📜 标题（Title）

**请提供这个Pull Request中提议的更改的简洁描述：**
<!-- Please provide a succinct description of the changes proposed in this pull request:. -->

- Add semantic runtime events and make per-room retry waits interruptible.
- 添加语义化运行时事件，并使单直播间的重试等待可以及时中断。

### 🔍 描述（Description）

**请描述这个PR做了什么/为什么这些更改是必要的：**
<!-- Please describe what this PR does / why these changes are necessary: -->

- This contribution is intentionally minimal and passive. It does not redesign or replace DouyinLiveRecorder's recording logic.

  Apart from one small bugfix that makes a per-room retry wait interruptible when that room is disabled, the existing recorder behavior is left unchanged.

  The main change is the addition of passive semantic runtime-event hooks around existing state transitions. These events are written as JSONL to:

  `logs/runtime_events.jsonl`

  This allows external GUIs, web frontends, monitoring applications, and automation tools to observe accurate recorder state in real time without needing to parse human-oriented console output.

  **The bridge observes existing recorder behavior; it does not alter the recording workflow.**

  The bridge is read-only and provides no command or control interface.

  Current events include:

  - `runtime_started`
  - `room_monitoring_started`
  - `room_monitoring_stopped`
  - `room_live`
  - `room_waiting`
  - `recording_started`
  - `recording_stopped`

  Depending on the event, additional information includes configured room URL, platform, anchor, quality, recording backend, output path/format, retry delay, calculated next-check time, stop reason, and FFmpeg return code.

  The event writer is intentionally best-effort. Failure to create or write the event log is ignored and does not affect recorder operation.

  Sensitive information such as cookies, passwords, authorization data, proxy credentials, signed/direct stream URLs, raw resolver responses, and FFmpeg command lines is not emitted.

  These changes originated while I was developing a separate graphical UI for DouyinLiveRecorder. That UI is still under development and is not part of this PR. The runtime-event bridge was deliberately designed as a generic integration mechanism so that other GUI developers, web frontends, monitoring tools, automation projects, and other external programs can use it as well.

- 本次贡献有意保持最小化和被动式设计，不会重新设计或替换 DouyinLiveRecorder 现有的录制逻辑。

  除了一处小型修复——当某个直播间被禁用时，可以及时中断该直播间自身的重试等待——其余现有录制行为保持不变。

  本次修改的主要内容是在现有状态转换周围增加被动式、语义化的运行时事件钩子。这些事件以 JSONL 格式写入：

  `logs/runtime_events.jsonl`

  这样，外部 GUI、Web 前端、监控程序和自动化工具可以实时获取准确的录制程序状态，而无需解析主要面向人工阅读的控制台输出。

  **该桥接仅观察现有录制程序的行为，不改变录制工作流程。**

  该桥接为只读方式，不提供命令或控制接口。

  当前事件包括：

  - `runtime_started`
  - `room_monitoring_started`
  - `room_monitoring_stopped`
  - `room_live`
  - `room_waiting`
  - `recording_started`
  - `recording_stopped`

  根据事件类型，还会提供已配置的直播间 URL、平台、主播、画质、录制后端、输出路径/格式、重试等待时间、计算出的下一次检查时间、停止原因以及 FFmpeg 返回码等信息。

  事件写入采用尽力而为（best-effort）方式。如果事件日志无法创建或写入，该错误会被忽略，不会影响录制程序本身的运行。

  事件中不会输出 Cookie、密码、授权信息、代理凭据、签名/直连直播流地址、原始解析器响应或 FFmpeg 命令行等敏感信息。

  这些修改源于我正在开发一个独立的 DouyinLiveRecorder 图形界面。该 UI 目前仍在开发中，不属于本 PR 的内容。运行时事件桥接被有意设计为通用集成机制，因此其他 GUI 开发者、Web 前端、监控工具、自动化项目以及其他外部程序也可以使用它。

### 📝 类型（Type of Change）

**这个PR引入了哪种类型的更改？（请勾选所有适用的选项）**
<!-- What type of change does this PR introduce? (Check all that apply)  -->

- [x] 修复Bug  <!-- Bugfix -->
- [x] 新功能  <!-- Feature -->
- [ ] 代码风格更新（格式化，局部变量） <!-- Code style update (formatting, local variables) -->
- [ ] 重构（改进代码结构） <!-- Refactoring (improving code structure) -->
- [ ] 构建相关更改（依赖项，构建脚本等）  <!-- Build-related changes (dependencies, build scripts, etc.) -->
- [ ] 其他：_请描述_  <!-- Other: _Please describe_ -->

### 🏗️ 测试（Testing）

**请描述您已经进行的测试：**
<!-- Please describe the tests you've done: -->

- The runtime-event hooks on the FFmpeg recording path were exercised with live Douyin rooms.

  Testing covered:

  - runtime startup
  - monitoring start/stop
  - live-room detection
  - recording start/stop
  - disabling and re-enabling a room
  - FFmpeg backend failure with return code
  - transition from backend failure to retry waiting
  - interruption of the retry wait by disabling the room
  - fresh monitoring/recording after re-enabling
  - multiple simultaneously monitored rooms
  - JSONL creation and event output in source mode
  - JSONL creation beside the executable in a PyInstaller onedir build

  Other FFmpeg-based platforms were not separately exercised as part of this contribution.

  The existing direct FLV recording logic was not changed; only passive runtime-event emissions were added around its existing control flow. The new `direct_flv` hooks were reviewed and syntax-checked.

  Live verification was also attempted using the Huajiao and Shopee example room URLs supplied by the project, but neither example produced an active live stream during testing. Therefore the newly added `direct_flv` event hooks could not yet be exercised during an actual direct-FLV recording session.

  This limitation concerns live verification of the newly added event reporting only, not the existing direct FLV recording functionality.

- FFmpeg 录制路径上的运行时事件钩子已使用实际的抖音直播间进行了测试。

  测试涵盖：

  - 运行环境启动
  - 直播间监测开始/停止
  - 直播状态检测
  - 录制开始/停止
  - 禁用和重新启用直播间
  - FFmpeg 后端失败及返回码
  - 从后端失败进入重试等待
  - 通过禁用直播间及时中断重试等待
  - 重新启用后重新开始监测/录制
  - 同时监测多个直播间
  - 源码模式下创建 JSONL 并写入事件
  - PyInstaller onedir 打包版本中在可执行文件旁创建 JSONL 事件文件

  本次贡献未单独测试其他基于 FFmpeg 的平台。

  本次贡献没有修改现有的 direct FLV 录制逻辑；只是在其现有控制流程周围增加了被动式运行时事件输出。新增的 `direct_flv` 事件钩子已经过代码审查和语法检查。

  我们还使用项目提供的花椒和 Shopee 示例直播间 URL 尝试进行了实际验证，但测试时两个示例都没有产生正在进行的直播。因此，新增的 `direct_flv` 事件钩子目前尚未能在真实的 direct-FLV 录制会话中触发验证。

  此限制仅涉及新增事件报告功能的实际直播验证，并不表示现有 direct FLV 录制功能存在问题。

**如果适用，请提供测试更改的说明：**
<!-- If applicable, provide instructions for testing your changes -->

- Start DouyinLiveRecorder normally and monitor `logs/runtime_events.jsonl`.

  A live room can be used to observe the transitions between monitoring, live detection, recording start and recording stop.

  Commenting a configured room with `#` can be used to verify `room_monitoring_stopped` and, when recording, `recording_stopped`.

  To test the retry-wait fix, allow a room to enter `room_waiting`, then disable the room with `#`. The room worker should stop promptly instead of waiting for the full retry interval.

- 正常启动 DouyinLiveRecorder，并监测 `logs/runtime_events.jsonl`。

  可以使用正在直播的直播间观察监测、直播检测、录制开始和录制停止之间的状态转换。

  在已配置直播间前添加 `#` 可以验证 `room_monitoring_stopped`；如果正在录制，还可以验证 `recording_stopped`。

  若要测试重试等待修复，可先让直播间进入 `room_waiting` 状态，然后使用 `#` 禁用该直播间。该直播间的工作线程应及时停止，而不是继续等待完整的重试间隔。

### 📋 检查清单（Checklist）

在您创建这个PR之前，请确保以下所有框都被勾选，方法是在每个框中放置一个`x`：
<!-- Before you create this PR, please ensure the following boxes are checked by placing an `x` in each box: -->

- [x] CONTRIBUTING：很抱歉，如果我有所遗漏还请见谅；我在仓库中没有找到 CONTRIBUTING（贡献指南）文档。  
      CONTRIBUTING: I apologize if I overlooked it, but I could not find a CONTRIBUTING document in the repository.
- [x] 我的更改没有产生新的警告  <!-- My changes generate no new warnings. -->
- [x] 本次更改已通过上述手动/集成测试；未添加自动化测试套件。  
      The changes were covered by the manual/integration testing described above; no automated test suite was added.
- [x] 我已经相应地更新了文档：新增 `RUNTIME_EVENTS.md`。  
      I have updated the documentation accordingly by adding `RUNTIME_EVENTS.md`.
- [x] 我遵循了这个项目的代码风格  <!-- I have followed the code style of this project. -->

**注意：** 这个PR在所有复选框被勾选之前不会被合并。
<!-- **Note:** This PR will not be merged until all checkboxes are ticked. -->

---

**感谢您的贡献！**
<!-- Thank you for your contribution! -->